### PR TITLE
Keyboard Navigation

### DIFF
--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -5,7 +5,7 @@ struct IntuneLogWatchCLI: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "intunelogwatch-cli",
         abstract: "Inspect MDM certificates from the command line",
-        version: "1.3.0"
+        version: "1.4.0"
     )
     
     @Flag(name: .shortAndLong, help: "Output in JSON format")

--- a/IntuneLogWatch.xcodeproj/project.pbxproj
+++ b/IntuneLogWatch.xcodeproj/project.pbxproj
@@ -312,7 +312,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -369,7 +369,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
@@ -385,12 +385,12 @@
 				CODE_SIGN_ENTITLEMENTS = IntuneLogWatch/IntuneLogWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.3.0;
+				CURRENT_PROJECT_VERSION = 1.4.0;
 				DEVELOPMENT_TEAM = G4MQ57TVLE;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = IntuneLogWatch/Info.plist;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Gil Burns";
 				INFOPLIST_KEY_NSMainStoryboardFile = Main;
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				INFOPLIST_KEY_SUFeedURL = "https://gilburns.github.io/IntuneLogWatch/appcast.xml";
@@ -399,8 +399,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.3.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gilburns.IntuneLogWatch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -416,12 +416,12 @@
 				CODE_SIGN_ENTITLEMENTS = IntuneLogWatch/IntuneLogWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.3.0;
+				CURRENT_PROJECT_VERSION = 1.4.0;
 				DEVELOPMENT_TEAM = G4MQ57TVLE;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = IntuneLogWatch/Info.plist;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Gil Burns";
 				INFOPLIST_KEY_NSMainStoryboardFile = Main;
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				INFOPLIST_KEY_SUFeedURL = "https://gilburns.github.io/IntuneLogWatch/appcast.xml";
@@ -430,8 +430,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.3.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gilburns.IntuneLogWatch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/IntuneLogWatch.xcodeproj/xcuserdata/gilburns.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/IntuneLogWatch.xcodeproj/xcuserdata/gilburns.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>IntuneLogWatch.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>intunelogwatch-cli.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/IntuneLogWatch/IntuneLogWatchApp.swift
+++ b/IntuneLogWatch/IntuneLogWatchApp.swift
@@ -326,7 +326,7 @@ struct IntuneLogWatchApp: App {
                     NotificationCenter.default.post(name: .openLogFile, object: nil)
                 }
                 .keyboardShortcut("o", modifiers: .command)
-                
+
                 Divider()
 
                 Button("Reload Local Logs") {
@@ -334,6 +334,14 @@ struct IntuneLogWatchApp: App {
                     NotificationCenter.default.post(name: .reloadLocalLogs, object: nil)
                 }
                 .keyboardShortcut("r", modifiers: .command)
+            }
+
+            CommandGroup(after: .textEditing) {
+                Button("Search Policies...") {
+                    // Post notification to focus search field
+                    NotificationCenter.default.post(name: .focusSearchField, object: nil)
+                }
+                .keyboardShortcut("f", modifiers: .command)
             }
             
             CommandGroup(replacing: .help) {
@@ -389,6 +397,9 @@ struct IntuneLogWatchApp: App {
 extension Notification.Name {
     static let openLogFile = Notification.Name("openLogFile")
     static let reloadLocalLogs = Notification.Name("reloadLocalLogs")
+    static let focusSearchField = Notification.Name("focusSearchField")
+    static let focusPolicyList = Notification.Name("focusPolicyList")
+    static let focusSearchFieldDirect = Notification.Name("focusSearchFieldDirect")
 }
 
 extension UTType {

--- a/IntuneLogWatch/LogEntryDetailView.swift
+++ b/IntuneLogWatch/LogEntryDetailView.swift
@@ -8,79 +8,156 @@
 import SwiftUI
 
 struct LogEntryDetailView: View {
-    let entry: LogEntry
+    let displayName: String
+    let bundleIdentifier: String
+    let policyType: PolicyType
+    let entries: [LogEntry]
+    @State private var currentIndex: Int
     @Environment(\.presentationMode) var presentationMode
+    
+    init(displayName: String, bundleIdentifier: String, policyType: PolicyType, entries: [LogEntry], currentIndex: Int) {
+        self.displayName = displayName
+        self.bundleIdentifier = bundleIdentifier
+        self.policyType = policyType
+        self.entries = entries
+        self._currentIndex = State(initialValue: currentIndex)
+    }
+    
+    private var entry: LogEntry {
+        entries[currentIndex]
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Log Entry Details")
-                        .font(.title2)
-                        .fontWeight(.semibold)
+            VStack(alignment: .leading, spacing: 4) {
+                
+                HStack {
+                    AppIconView(
+                        bundleId: bundleIdentifier,
+                        policyType: policyType,
+                        size: 48
+                    )
                     
-                    HStack {
-                        levelIcon
-                        Text(entry.level.displayName)
-                            .font(.caption)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(displayName)
+                            .font(.title2)
+                            .fontWeight(.semibold)
                         
-                        Spacer()
-                        
-                        Text(formatDateTime(entry.timestamp))
+                        Text("Log Entry Details")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
                 }
                 
-                Spacer()
+                Divider()
                 
-                Button("Close") {
-                    presentationMode.wrappedValue.dismiss()
-                }
-                .keyboardShortcut(.escape)
-            }
-            
-            VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    Text("Component:")
-                        .fontWeight(.medium)
-                    Text(entry.component)
-                        .foregroundColor(.secondary)
+                    levelIcon
+                    Text(entry.level.displayName)
+                        .font(.caption)
                     
                     Spacer()
                     
+                    Text(formatDateTime(entry.timestamp))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+            
+            Grid(alignment: .center, horizontalSpacing: 10, verticalSpacing: 4) {
+                GridRow {
+                    Text("Component:")
+                        .fontWeight(.medium)
+                        .gridColumnAlignment(.trailing)
+                    
+                    Text(entry.component)
+                        .foregroundColor(.secondary)
+                        .gridColumnAlignment(.leading)
+                    
+                    Spacer()
+                        .gridColumnAlignment(.center)
+                    
                     Text("Thread:")
                         .fontWeight(.medium)
+                        .gridColumnAlignment(.trailing)
+                    
                     Text(entry.threadId)
                         .foregroundColor(.secondary)
+                        .gridColumnAlignment(.trailing)
                 }
                 .font(.caption)
                 
-                if let policyId = entry.policyId {
-                    HStack {
+                GridRow {
+                    if let policyId = entry.policyId {
                         Text("Policy ID:")
                             .fontWeight(.medium)
+                            .gridColumnAlignment(.trailing)
+                        
                         Text(policyId)
                             .foregroundColor(.secondary)
                             .textSelection(.enabled)
+                            .gridColumnAlignment(.leading)
+                        
+                        Spacer()
+                            .gridColumnAlignment(.center)
+                        
+                        Text("")
+                            .gridColumnAlignment(.trailing)
+                        
+                        Text("")
+                            .gridColumnAlignment(.trailing)
+                    } else {
+                        Text("")
+                            .gridColumnAlignment(.trailing)
+                        Text("")
+                            .gridColumnAlignment(.leading)
+                        Spacer()
+                            .gridColumnAlignment(.center)
+                        Text("")
+                            .gridColumnAlignment(.trailing)
+                        Text("")
+                            .gridColumnAlignment(.trailing)
                     }
-                    .font(.caption)
                 }
+                .font(.caption)
 
-                if let bundleId = entry.bundleId {
-                    HStack {
+                GridRow {
+                    if let bundleId = entry.bundleId {
                         Text("Bundle ID:")
                             .fontWeight(.medium)
+                            .gridColumnAlignment(.trailing)
+                        
                         Text(bundleId)
                             .foregroundColor(.secondary)
                             .textSelection(.enabled)
+                            .gridColumnAlignment(.leading)
+                        
+                        Spacer()
+                            .gridColumnAlignment(.center)
+                        
+                        Text("")
+                            .gridColumnAlignment(.trailing)
+                        
+                        Text("")
+                            .gridColumnAlignment(.trailing)
+                    } else {
+                        Text("")
+                            .gridColumnAlignment(.trailing)
+                        Text("")
+                            .gridColumnAlignment(.leading)
+                        Spacer()
+                            .gridColumnAlignment(.center)
+                        Text("")
+                            .gridColumnAlignment(.trailing)
+                        Text("")
+                            .gridColumnAlignment(.trailing)
                     }
-                    .font(.caption)
                 }
+                .font(.caption)
+                
             }
-            .padding()
-            .background(Color(NSColor.controlBackgroundColor))
-            .cornerRadius(8)
+            
             
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
@@ -90,10 +167,12 @@ struct LogEntryDetailView: View {
                     Spacer()
                     
                     Button(action: copyMessage) {
-                        Label("Copy", systemImage: "doc.on.clipboard")
+                        Label("Copy", systemImage: "document.on.clipboard")
                     }
-                    .buttonStyle(BorderedButtonStyle())
+                    .buttonStyle(PressedCopyButtonStyle())
                     .controlSize(.small)
+                    .keyboardShortcut("c", modifiers: .command)
+                    
                 }
                 
                 ScrollView {
@@ -102,7 +181,7 @@ struct LogEntryDetailView: View {
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .frame(maxHeight: 200)
+                .frame(minHeight: 90, idealHeight: 90, maxHeight: 200)
                 .padding()
                 .background(Color(NSColor.textBackgroundColor))
                 .cornerRadius(8)
@@ -120,10 +199,11 @@ struct LogEntryDetailView: View {
                     Spacer()
                     
                     Button(action: copyRawLine) {
-                        Label("Copy", systemImage: "doc.on.clipboard")
+                        Label("Copy", systemImage: "document.on.clipboard")
                     }
-                    .buttonStyle(BorderedButtonStyle())
+                    .buttonStyle(PressedCopyButtonStyle())
                     .controlSize(.small)
+                    .keyboardShortcut("c", modifiers: .control)
                 }
                 
                 ScrollView {
@@ -132,7 +212,7 @@ struct LogEntryDetailView: View {
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .frame(maxHeight: 100)
+                .frame(minHeight: 90, idealHeight: 90, maxHeight: 200)
                 .padding()
                 .background(Color(NSColor.textBackgroundColor))
                 .cornerRadius(8)
@@ -140,6 +220,36 @@ struct LogEntryDetailView: View {
                     RoundedRectangle(cornerRadius: 8)
                         .stroke(Color(NSColor.separatorColor), lineWidth: 1)
                 )
+            }
+            
+            HStack {
+                Spacer()
+                
+                HStack(spacing: 8) {
+                    Button(action: previousEntry) {
+                        Image(systemName: "chevron.left")
+                    }
+                    .disabled(currentIndex <= 0)
+                    .keyboardShortcut(.leftArrow, modifiers: .command)
+                    
+                    Text("\(currentIndex + 1) of \(entries.count)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    
+                    Button(action: nextEntry) {
+                        Image(systemName: "chevron.right")
+                    }
+                    .disabled(currentIndex >= entries.count - 1)
+                    .keyboardShortcut(.rightArrow, modifiers: .command)
+                }
+                
+                Spacer()
+                
+                Button("Close") {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .keyboardShortcut(.escape)
+                
             }
         }
         .padding()
@@ -180,5 +290,37 @@ struct LogEntryDetailView: View {
         formatter.dateStyle = .short
         formatter.timeStyle = .medium
         return formatter.string(from: date)
+    }
+    
+    private func previousEntry() {
+        if currentIndex > 0 {
+            currentIndex -= 1
+        }
+    }
+    
+    private func nextEntry() {
+        if currentIndex < entries.count - 1 {
+            currentIndex += 1
+        }
+    }
+}
+
+
+struct PressedCopyButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color(NSColor.controlBackgroundColor))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color(NSColor.separatorColor), lineWidth: 1)
+                    )
+            )
+            .scaleEffect(configuration.isPressed ? 0.90 : 1.0)
+            .opacity(configuration.isPressed ? 0.8 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
     }
 }

--- a/IntuneLogWatch/PolicyDetailView.swift
+++ b/IntuneLogWatch/PolicyDetailView.swift
@@ -34,7 +34,12 @@ struct PolicyDetailView: View {
                     .foregroundColor(.secondary)
             }
             .padding()
-            
+
+            Text("(Double click on a log entry to view or copy details)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Spacer()
+
             if showingRawLogs {
                 rawLogView
             } else {
@@ -42,8 +47,10 @@ struct PolicyDetailView: View {
             }
         }
         .sheet(item: $detailLogEntry) { entry in
-            LogEntryDetailView(entry: entry)
-                .frame(minWidth: 700, minHeight: 550)
+            if let index = policy.entries.firstIndex(where: { $0.id == entry.id }) {
+                LogEntryDetailView(displayName: policy.displayName, bundleIdentifier: policy.bundleId ?? "", policyType: policy.type, entries: policy.entries, currentIndex: index)
+                    .frame(minWidth: 700, minHeight: 550)
+            }
         }
     }
     
@@ -238,9 +245,10 @@ struct PolicyDetailView: View {
                     Image(systemName: policyIdCopied ? "checkmark" : "doc.on.clipboard")
                         .font(.caption2)
                         .foregroundColor(policyIdCopied ? .green : .secondary)
+                        .frame(width: 24, height: 24)
                 }
                 .buttonStyle(BorderlessButtonStyle())
-                .help(policyIdCopied ? "Copied \(copiedText)!" : "Copy Policy ID\r⌥-click for Graph API URL,\r ⌃-click for Intune Portal URL")
+                .help(policyIdCopied ? "Copied \(copiedText)!" : "Click to copy Policy ID\r⌥ + Click for Graph API URL,\r ⌃ + Click for Intune Portal URL")
             }
             Text(policy.policyId)
                 .font(.caption)


### PR DESCRIPTION
Added the ability to navigate most of the interface elements using keyboard controls. Up, Down, Left and Right arrows move through the Sync events, policy events. Return key will open the log details view and esc will close it.